### PR TITLE
Fix error "invalid mode: r"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ services:
       JAVA_TOOL_OPTIONS: -javaagent:/jacoco/lib/jacocoagent.jar=excludes=*_javassit_*:javax.xml.soap.*:oasis.*,output=tcpserver,address=*
     image: jboss/wildfly
     volumes_from:
-    - service:jacoco:r
+    - service:jacoco:ro
 version: '2.0'
 
 ```


### PR DESCRIPTION
When running the example from the readme, I get "invalid mode: r" because it should be "ro"